### PR TITLE
功能增强

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,27 @@
 
 支持 KernelSU、APatch、Magisk下运行。调用对应框架busybox实现crond定时。
 
+从 `1.0.3` 版本开始支持安装时通过创建文件 `/sdcard/crond4android.setup` 或者音量键来控制是否安装命令行
+
+`/sdcard/crond4android.setup` 文件内容为1则自动安装crontab命令，其他则不安装
+> 通常用于解决环境检测时，非必要不推荐安装crontab命令，且安装后会和lsposed内测版冲突，导致lsposed失效，原因暂时未知。建议使用别名方式。
+
 ## 数据目录
 
 日志: `/data/adb/crond/run.log`
 
 任务数据: `/data/adb/crond/`
 
-crontab: `/system/xbin/crontab`
+crontab: `/system/bin/crontab`
 `注意：如果替换了root实现方案，记得修改这个脚本，或者重新安装一次，不然无法执行。`
 
 创建`/data/adb/crond/KEEP_ON_UNINSTALL`可以在卸载模块时保留任务数据
+
 ## 使用样例
 
 ```shell
 # 创建任务 (也可以直接编辑文件)
+# alias crontab="root方案路径(参考customize.sh)/busybox crontab -c '/data/adb/crond'"
 echo '30 4 * * * echo "" > /data/adb/crond/run.log' >> /data/adb/crond/root # for root user 
 # 查看任务
 crontab -l

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-# 版本 1.0.2
+# 版本 1.0.3
 
-修复 magisk busybox 路径错误 by @dawn-lc in #1
+- 安装时通过创建文件 `/sdcard/crond4android.setup` 或者音量键来控制是否安装命令行
+- 修改crontab命令的安装路径到`/system/bin/`
 
-修复命令行无效的BUG by @powerAn2020 in #2
+> 通常用于解决环境检测时，非必要不推荐安装crontab命令，且安装后会和lsposed内测版冲突，导致lsposed失效，原因未知。建议使用别名方式。

--- a/customize.sh
+++ b/customize.sh
@@ -1,31 +1,66 @@
 #!/system/bin/sh
 if [ "$BOOTMODE" != true ]; then
-  ui_print "-----------------------------------------------------------"
+  ui_print "------------------------------"
   ui_print "! Please install in Magisk Manager or KernelSU Manager or APatch Manager"
   ui_print "! Install from recovery is NOT supported"
-  abort "-----------------------------------------------------------"
+  abort "------------------------------"
 fi
-cd ${MODPATH}
+
 cronDataDir='/data/adb/crond'
 if [ ! -d "${cronDataDir}" ]; then
   ui_print "- Creating ${cronDataDir}"
   mkdir -p "${cronDataDir}" && touch "${cronDataDir}/root"
 fi
 
-ui_print "- Installing crontab command"
-mkdir -p "${MODPATH}/system/xbin"
-{
-  echo "#!/system/bin/sh"
-  if [ "$KSU" = true ]; then
-    echo "/data/adb/ksu/bin/busybox crontab -c '${cronDataDir}'"' $@'
-  elif [ "$APATCH" = true ]; then
-    echo "/data/adb/ap/bin/busybox crontab -c '${cronDataDir}'"' $@'
+install_crontab(){
+  ui_print "- Installing crontab command"
+  mkdir -p "${MODPATH}/system/bin"
+  {
+    echo "#!/system/bin/sh"
+    if [ "$KSU" = true ]; then
+      echo "/data/adb/ksu/bin/busybox crontab -c '${cronDataDir}'"' $@'
+    elif [ "$APATCH" = true ]; then
+      echo "/data/adb/ap/bin/busybox crontab -c '${cronDataDir}'"' $@'
+    else
+      echo "/data/adb/magisk/busybox crontab -c '${cronDataDir}'"' $@'
+    fi
+  } > "${MODPATH}/system/bin/crontab"
+}
+
+ui_print ""
+ui_print "------------------------------"
+ui_print "- Do you want install crontab command?"
+ui_print "- This operation will not affect the operation of background services."
+ui_print "- You can manage it through the UI or by setting up an alias to run it."
+ui_print "- You can create the /sdcard/crond4android.setup file to automatically install the crontab command. Write 0 to skip installation, or write 1 to proceed with installation."
+ui_print ""
+
+if [ -f /sdcard/crond4android.setup ]; then
+  ui_print "- Detected file /sdcard/crond4android.setup ."
+  if [ "$(sed -n 1p /sdcard/crond4android.setup)" = "1" ]; then
+    ui_print "- Auto install crontab command."
+    install_crontab
   else
-    echo "/data/adb/magisk/busybox crontab -c '${cronDataDir}'"' $@'
+    ui_print "- Skip installation crontab command."
   fi
-} > "${MODPATH}/system/xbin/crontab"
+else
+  ui_print "- Press Vol UP to install crontab command"
+  ui_print "- Other: No"
+  # 循环检测按键事件
+  while true ; do
+    getevent -lc 1 2>&1 | grep KEY_VOLUME > $TMPDIR/events
+    sleep 1
+    if $(cat $TMPDIR/events | grep -q KEY_VOLUMEUP) ; then
+      install_crontab
+      break
+    else
+      ui_print "- Skip installation crontab command."
+      break
+    fi
+  done
+fi
+
 
 ui_print "- Setting permissions"
-set_perm "${MODPATH}/system/xbin/crontab" 0 0 0755
-set_perm "${MODPATH}/service.sh" 0 0 0755
-set_perm "${MODPATH}/uninstall.sh" 0 0 0755
+set_perm_recursive $MODPATH 0 0 0755 0755
+ui_print "- The background service installation is complete."

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=crond4android
 name=Crond for Android
-version=1.0.1
-versionCode=101
+version=1.0.3
+versionCode=103
 author=powerAn2020
 description=Busybox Crond with service scripts for Android
 updateJson=https://raw.githubusercontent.com/powerAn2020/crond4android/main/update.json

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.0.2",
-    "versionCode": 102,
-    "zipUrl": "https://github.com/powerAn2020/crond4android/releases/download/1.0.2/crond4android_v1.0.2.zip",
+    "version": "1.0.3",
+    "versionCode": 103,
+    "zipUrl": "https://github.com/powerAn2020/crond4android/releases/download/1.0.3/crond4android_v1.0.3.zip",
     "changelog": "https://raw.githubusercontent.com/powerAn2020/crond4android/main/changelog.md"
 }


### PR DESCRIPTION
- 安装时通过创建文件 `/sdcard/crond4android.setup` 或者音量键来控制是否安装命令行
- 修改crontab命令的安装路径到`/system/bin/`

`/sdcard/crond4android.setup` 文件内容为1则自动安装crontab命令，其他则不安装
> 通常用于解决环境检测，非必要不推荐安装crontab命令，且安装后会和lsposed内测版冲突，导致lsposed失效，原因暂时未知。建议使用别名方式。
